### PR TITLE
Refactor: move edit merchant button from index to show page

### DIFF
--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -18,7 +18,6 @@
 
         <p><%= link_to "#{merchant.name}", "/admin/merchants/#{merchant.id}" %>
 
-        <%= link_to "Edit", "/admin/merchants/#{merchant.id}/edit", local: true, method: :get %>
         <% if merchant.status == 'Enabled' %>
           <%= button_to "Disable", "/admin/merchants/#{merchant.id}/update?button=disabled", local: true, method: :patch %>
         <% else %>

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,1 +1,4 @@
 <h1><%= @merchant.name %></h1>
+<p>
+<%= button_to 'Edit', "/admin/merchants/#{@merchant.id}/edit", local: true, method: :get %>
+</p>

--- a/spec/features/admin/merchants/edit_spec.rb
+++ b/spec/features/admin/merchants/edit_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe 'admin merchant index page' do
     @merchant1 = Merchant.create(name: "Robespierre the Second")
   end
 
-  it 'can redirect to edit page from admin index' do
+  it 'can redirect to edit page from admin merchant show' do
     # require "pry"; binding.pry
-    visit '/admin/merchants'
+    visit admin_merchant_path(@merchant1.id)
+    save_and_open_page
+    expect(page).to have_content("#{@merchant1.name}")
 
-    within(".merchant_#{@merchant1.id}") do
-      click_on 'Edit'
-    end
+    click_on 'Edit'
 
     expect(current_path).to eq("/admin/merchants/#{@merchant1.id}/edit")
   end


### PR DESCRIPTION
Moved the edit button from admin merchants index page to the show page, updated test.